### PR TITLE
feat: Linux compatibility (looking for NASM in PATH)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
 import os
 import sys
 import ctypes
+import shutil
 import struct
 import subprocess
-import shutil
 
 try:
     import sim5960
@@ -32,7 +32,6 @@ def p16(value):
 #------------------------------------------------------------------------------
 
 BASE_PATH = os.path.join(os.path.dirname(__file__))
-NASM_EXE_PATH = os.path.join(BASE_PATH, "nasm.exe")
 ENDGAME_PATH = os.path.join(BASE_PATH, "ENDGAME")
 
 #
@@ -79,12 +78,12 @@ def compile_shellcode(shellcode_filepath, debug=False):
     """
     assert shellcode_filepath.endswith(".asm")
 
-
+    # for Windows-based systems just use the local nasm.exe included in the repo
     if os.name == "nt":
-        # Windows operating system
-        nasm_executable = NASM_EXE_PATH
+        nasm_executable = os.path.join(BASE_PATH, "nasm.exe")
+
+    # for POSIX systems (linux, macOS) look for nasm in the system path
     elif os.name == "posix":
-        # POSIX systems (linux, macOS)
         if not shutil.which("nasm"):
             raise FileNotFoundError("NASM cannot be found in PATH")
         nasm_executable = "nasm"
@@ -93,11 +92,11 @@ def compile_shellcode(shellcode_filepath, debug=False):
     if debug:
         command.insert(1, "-dDEBUG")
 
-    # Run nasm and capture the output and errors
+    # run nasm and capture the output and errors
     print("[*] Assembling shellcode... ", end="")
     result = subprocess.run(command, capture_output=True)
 
-    # Check the return code of the command
+    # check the return code to determine if compilation succeeded
     if result.returncode == 0:
         output = result.stdout.decode()
         if output.strip():

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import sys
 import ctypes
 import struct
 import subprocess
+import shutil
 
 try:
     import sim5960
@@ -31,7 +32,7 @@ def p16(value):
 #------------------------------------------------------------------------------
 
 BASE_PATH = os.path.join(os.path.dirname(__file__))
-NASM_PATH = os.path.join(BASE_PATH, "nasm.exe")
+NASM_EXE_PATH = os.path.join(BASE_PATH, "nasm.exe")
 ENDGAME_PATH = os.path.join(BASE_PATH, "ENDGAME")
 
 #
@@ -78,11 +79,21 @@ def compile_shellcode(shellcode_filepath, debug=False):
     """
     assert shellcode_filepath.endswith(".asm")
 
-    # Run nasm.exe and capture the output and errors
-    command = [NASM_PATH, shellcode_filepath]
+
+    if os.name == "nt":
+        # Windows operating system
+        nasm_executable = NASM_EXE_PATH
+    elif os.name == "posix":
+        # POSIX systems (linux, macOS)
+        if not shutil.which("nasm"):
+            raise FileNotFoundError("NASM cannot be found in PATH")
+        nasm_executable = "nasm"
+
+    command = [nasm_executable, shellcode_filepath]
     if debug:
         command.insert(1, "-dDEBUG")
 
+    # Run nasm and capture the output and errors
     print("[*] Assembling shellcode... ", end="")
     result = subprocess.run(command, capture_output=True)
 


### PR DESCRIPTION
Checks which platform the script is ran on.

- If windows, use the relative path to nasm.exe
- If POSIX, check if nasm can be found in PATH and execute from there